### PR TITLE
Set accepted encoding type

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -57,7 +57,7 @@ func (c *Client) doFullyTypedRequest(method, path string, data io.Reader, conten
 	statusCode = response.StatusCode
 
 	defer response.Body.Close()
-	rawBody, err := ioutil.ReadAll(response.Body)
+	rawBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -40,6 +40,7 @@ func (c *Client) doFullyTypedRequest(method, path string, data io.Reader, conten
 	if err != nil {
 		return
 	}
+	request.Header.Set("Accept-Encoding", "identity")
 	if contentType != "" {
 		request.Header.Set("Content-Type", contentType)
 	}


### PR DESCRIPTION
Setting the `Accept-Encoding` fixes https://github.com/camptocamp/terraform-provider-geoserver/issues/29 