### PR TITLE
Set type to WMS by default

### DIFF
--- a/client/wmsstore.go
+++ b/client/wmsstore.go
@@ -30,6 +30,14 @@ type WmsStore struct {
 	MaxConnections             int                 `xml:"maxConnections"`
 	ReadTimeOut                int                 `xml:"readTimeout"`
 	ConnectTimeOut             int                 `xml:"connectTimeout"`
+	Type             	   string              `xml:"type"`
+}
+
+// NewWmsStore creates a new WmsStore with default values
+func NewWmsStore() *WmsStore {
+	return &WmsStore{
+		Type: "WMS",
+	}
 }
 
 // GetWmsStores returns the list of the wms stores


### PR DESCRIPTION
Includes a constructor function which allows to set default values.
In particular the Type value was missed, so in case of a WMSStore creation, then in Geoserver, the column Type is missed (as in capture below)

![image](https://github.com/user-attachments/assets/a693c4ae-8c19-49ea-aa3b-d06ed84665c8)

BTW, the datastore works fine, it's only a matter of information associated to the datastore (the type in this case)